### PR TITLE
Removing pyEDFlib from setup.py for python 3.7 for time being

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ REQUIRED = [
     "qtpy",
     "pyqtgraph",
     "qtawesome",
-    "pyedflib",
-    "cython",
+    "pyedflib;python_version<'3.7'",
+    "cython;python_version<'3.7'",
 ]
 
 TESTS_REQUIRE = ["pytest", "pytest-qt", "pytest-runner"]

--- a/timeview/__version__.py
+++ b/timeview/__version__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
-VERSION = (0, 1, 2)
+VERSION = (0, 1, 3)
 
 __version__ = ".".join(map(str, VERSION))


### PR DESCRIPTION
pyedflib is causing too many headaches with python 3.7 installations for the time being; installation is blowing up, removing dependency and EDF support for python 3.7 only for time being.